### PR TITLE
lrefpos (nx/y/z) now working in oxdna_hbond. Being comm'ed and MPI wo…

### DIFF
--- a/src/CG-DNA/bond_oxdna_fene.cpp
+++ b/src/CG-DNA/bond_oxdna_fene.cpp
@@ -255,7 +255,8 @@ void BondOxdnaFene::compute(int eflag, int vflag)
     if (evflag)
       ev_tally_xyz(a, b, nlocal, newton_bond, ebond, delf[0], delf[1], delf[2], x[a][0] - x[b][0],
                    x[a][1] - x[b][1], x[a][2] - x[b][2]);
-  }
+  } 
+  atom->lrefpos_flag = 0; // reset for next timestep
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/CG-DNA/pair_oxdna_hbond.h
+++ b/src/CG-DNA/pair_oxdna_hbond.h
@@ -41,6 +41,11 @@ class PairOxdnaHbond : public Pair {
   void write_data(FILE *);
   void write_data_all(FILE *);
   void *extract(const char *, int &);
+  
+  virtual int pack_forward_comm(int, int *, double *, int, int *);
+  virtual void unpack_forward_comm(int, int, double *);
+  int pack_reverse_comm(int, int, double *);
+  void unpack_reverse_comm(int, int *, double *);
 
  protected:
   // h-bonding interaction
@@ -67,6 +72,9 @@ class PairOxdnaHbond : public Pair {
   double **a_hb8, **theta_hb8_0, **dtheta_hb8_ast;
   double **b_hb8, **dtheta_hb8_c;
 
+  // per-atom arrays for q_to_exyz storage
+  double **nx, **ny, **nz;
+  
   int seqdepflag;
 
   virtual void allocate();

--- a/src/atom.cpp
+++ b/src/atom.cpp
@@ -649,6 +649,7 @@ void Atom::set_atomflag_defaults()
   rho_flag = esph_flag = cv_flag = vest_flag = 0;
   dpd_flag = edpd_flag = tdpd_flag = 0;
   sp_flag = 0;
+  lrefpos_flag = 0;
   x0_flag = 0;
   smd_flag = damage_flag = 0;
   mesont_flag = 0;

--- a/src/atom.h
+++ b/src/atom.h
@@ -190,6 +190,10 @@ class Atom : protected Pointers {
   // SPIN package
 
   int sp_flag;
+  
+  // CG-DNA package
+  
+  int lrefpos_flag;
 
   // MACHDYN package
 


### PR DESCRIPTION
…rking (#7)

* use the term 'website' consistently (and not also 'web site')

* update for clang-format

* clarify

* split off the programming/submission style guide to a separate file

* Updates to support ROCm 4.3 in GPU package

* update and reorder the description of the process for submitting contributions

* correct and clarify Python compatibility

* refactor style guide and integrate text from issue

* update contribution guidelines for github

* mention when testing may be added

* integrate file with description of include file conventions

* update github workflow doc

* adapt section about domain decomposition from paper

* use a more compact image

* add communication section

* update man page with missing flags and correct URLs

* improve the load imbalance viz

* add section about neighbor list construction

* break large file into multiple smaller files by section and add toctree

* fix typo

* add section about parallelization in the OPENMP package

* add -skipruin to help message

* add discussion of OpenMP parallelization

* spelling

* add section on PPPM

* use larger version of FFT grid comm image

* minor tweak

* Update compute angle doc page

* Update Singularity definitions to use ROCm 4.3

* Update CUDA container definitions to CUDA 11.4

* Update container definitions to include PLUMED 2.7.2

* Update more definition files

* RHEL8/CentOS8 PowerTools is now powertools

* Add Rocky Linux 8 container definition

* Add omega field to numpy_wrapper detection

* Return None in case of null pointer

* Add more atom fields in numpy_wrapper and correct csforce size

* must not clear force array. will segfault in hybrid atom styles

* update example for dynamically loading LAMMPS with current library API

* update example to use current library interface. No need to use the namespace.

* add note to README files about age of the example

* simplify building shared libs on windows

* detect a few more compilers

* Revert "simplify building shared libs on windows"

This reverts commit fa3429ab022b6bbb680011fee9a33f0a77839e1e.

* step version strings for next patch release

* fix mingw 32-bit vs 64-bit craziness

* detect C++20 standard

* build "fat" cuda binaries only with known toolkits

* spelling

* Try to improve the pair style hybrid docs

This specifically tries to avoid the ambiguous use of "mixing" and
clarify that similar is still different when pair styles are concerned.
See discussion here: https://matsci.org/t/confusion-about-mixing-and-pair-coeff-section/38317/3

* spelling

* use nullptr

* use symbolic constant

* small optimization

* use cmath header instead of math.h

* use explicit scoping when virtual dispatch is not available.

* cosmetic changes

* simplify/optimize code

* simplify

* Bugfix from Trung for crashes in pppm/gpu without local atoms

* fix typo

* refer to "XXX Coeffs" sections consistently

* small tweaks from static code analysis

* fix small bug

* small tweaks

* simplify and modernize code a little

* use correct data type for MPI calls

* simplify/modernize

* remove dead code

* about 1.5x speedup for pair style comb3 by using MathSpecial::powint()

* small performance optimization for pair style comb

* simplify

* modernize

* simplify

* removed dead code, reformat

* modernize

* use explicit scoping when virtual dispatch is not (yet) available

* reformat for increased readability

* move misplaced #endif and make code more readable

* make sure err_flag is initialized

* modernize

* remove redundant code: all struct members are initialized to defaults in the constructor

* enforce initialization and thus silence compiler warnings

* fix typo

* provide more comprehensive suggestions for GPU neighbor list errors

* add utils::logical() function to complement the *numeric() functions

* Add stable link in docs

* revert modernization change (for now)

* remove unused variable

* include EXTRA-DUMP in "most"

* small tweaks

* simplify

* Add log file printing of KIM search directories in 'kim init'

* use clang-format on kim_init.cpp

* Improve style in response to Axel's suggestions

* initialize all members

* format changes

* simplify. use utils::strdup() more.

* small corrections

* apply fix from balance command to fix balance

* dead code removal

* reformat strings

* implement utils::current_date() convenience function to reduce replicated code

* update list and order of include files from include-what-you-use analysis

* handle changes in GAP repo

* a few remaining updates to include statements

* expand mapping to handle "style_*.h" header files correctly.

* add support for compilation of OpenCL loader on FreeBSD

* more iwyu header updates

* small correction

* fix typo

* a few more (final?) IWYU updates

* expand tests for numeric values

* return int instead of bool to minimize code changes

* fix spelling issues

* some applications of the new function

* fix typo

* Change "offsite" to "external" to correct broken URLs to lammps.org

* improve error message

* insert missing atom-ID

* convert yes/no on/off flags in the package command(s)

* update version strings

* update death tests for change in error message

* correctly specify the destructor function name.

* apply utils::logical() to more commands

* apply utils::logical() in more places

* for consistency with utils::logical()

* only accept lower case to be consistent with the rest of the input

* a few more converted commands and updates for unit tests

* modernize and fix some memory leaks

* adjust for compatibility with C++20 compilers

* do not downgrade C++ standard when adding the KOKKOS package

* undo "risky" C++20 related changes

* mention how to set the path to the fftw3_omp library

* correct paths to downloaded PACE package sources in lib

* Update CMake variable descriptions

* possible workaround for some GPU package neighbor list issue

* final chunk of changes to apply utils::logical()

* update suffix command unit tests

* update citation info with new LAMMPS paper reference and acknowledge it

* update some formulations as suggested by @sjplimp

* add check and suitable error message when fp64 is required but not available

* do not call memset on a null pointer

* fix string formatting bugs in fix npt/cauchy

* must use a soft core potential to avoid a singularity

* in floating point math a*b may be zero even if both a>0 and b>0

* use proper integer type for atom IDs

* Building voro++ lib as part of LAMMPS requires the "patch" program

* silence output from hwloc when launching LAMMPS

* detect double precision support according to OpenCL specs (1.2 and later)

* Fix bug in Kokkos pair_eam_alloy

* calling fwrite() with a null pointer causes undefined behavior. avoid it.

* cosmetic

* apply current include file conventions

* include zstd libs in windows build

* update .gitignore for recent additions

* make check more obvious

* step version strings for stable release

* Adjust for kim-api bug

* cleaner variant of version check, add directory numbering

* hbond comm added for rsq_hb

* rsq_hb removed, exyz added (no MPI comm yet)

* Fix Colvars output files not written with "run 0"

See:
  https://github.com/Colvars/colvars/commit/ff2f0d39ee5
which fixes a bug introduced in:
  https://github.com/Colvars/colvars/commit/1e964a542b

The message applies to NAMD, but the logic used in LAMMPS when handling "run 0" is very similar.

The Colvars version string is also updated, however this commit does not
include other changes, such as the following:
  https://github.com/Colvars/colvars/pull/419
which were not fully completed before the LAMMPS Summer 2021 finalization.

* add -std=c++11 to a number of machine makefiles for traditional make build

* copy request to mention lammps.org form home page instructions for citing

* be more specific about what the name of the LAMMPS executable can be

also provide a few more examples without a machine suffix

* small tweak

* remove references to USER packages, have package lists alphabetically sorted

"make package-update" or "make pu" must be processed in the special order
because of inter-package dependencies

* make "make package-update" and "make package-overwrite" less verbose

* freeze versions of pip packages for processing the manual of the stable version

this way we avoid surprises in case one of the packages get updated
to an incompatible new version. these are know-to-work versions.

* make sure the one_coeff flag is applied to sub-styles

since the check for Pair::one_coeff was moved to the Input class (to
reduce redundant code), hybrid substyles could "escape" that requirement.
Thus checks have to be added to the hybrid coeff() methods.

* Prevent neigh list from copying "unique" stencil/bin

* compiling ML-HDNNP with downloaded n2p2 lib requires the sed command

* detect and error out if BLAS/LAPACK libraries variables are a list

This will cause external project compilation to fail since the semi-colons
are converted to blanks, but one cannot properly escape the variables.
So far the only viable solution seems to be to convert the scripts from
using ExternalProject_add() to FetchContent and add_subdirectory()

* portability improvement

* must have patch command available to compile ScaFaCoS

* only need Tcl not Tk to compile Tcl swig wrapper

* correctly handle Tcl stub library if available

* add missing keyword

* hbond_pos added, MPI and values ok, Pair time slow.

* make C library example work with strict C compilers

* silence compiler warnings

* make Nevery keyword per-reaction

* recover cross-compilation with mingw64

* reverted wrong approach from last commits

- now intpos flag
- hbond_pos added
- (a/b)xyz WiP

* lrefpos working in serial, MPI wrong

* attempt to merge doubles into n(xyz)[3]

* save

* Update pair_oxdna_hbond.cpp

* hbond now working for MPI, comming lrefpos

Co-authored-by: Axel Kohlmeyer <akohlmey@gmail.com>
Co-authored-by: Richard Berger <richard.berger@temple.edu>
Co-authored-by: Ryan S. Elliott <relliott@umn.edu>
Co-authored-by: Stan Gerald Moore <stamoor@sandia.gov>
Co-authored-by: Giacomo Fiorin <giacomo.fiorin@gmail.com>
Co-authored-by: Jacob Gissinger <jrgiss05@gmail.com>

**Summary**

<!--Briefly describe the new feature(s), enhancement(s), or bugfix(es) included in this pull request.-->

**Related Issue(s)**

<!--If this addresses an open GitHub issue for this project, please mention the issue number here, and describe the relation. Use the phrases `fixes #221` or `closes #135`, when you want an issue to be automatically closed when the pull request is merged-->

**Author(s)**

<!--Please state name and affiliation of the author or authors that should be credited with the changes in this pull request. If this pull request adds new files to the distribution, please also provide a suitable "long-lived" e-mail address (ideally something that can outlive your institution's e-mail, in case you change jobs) for the *corresponding* author, i.e. the person the LAMMPS developers can contact directly with questions and requests related to maintenance and support of this contributed code.-->

**Licensing**

By submitting this pull request, I agree, that my contribution will be included in LAMMPS and redistributed under either the GNU General Public License version 2 (GPL v2) or the GNU Lesser General Public License version 2.1 (LGPL v2.1).

**Backward Compatibility**

<!--Please state whether any changes in the pull request will break backward compatibility for inputs, and - if yes - explain what has been changed and why-->

**Implementation Notes**

<!--Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in LAMMPS are affected-->

**Post Submission Checklist**

<!--Please check the fields below as they are completed **after** the pull request has been submitted. Delete lines that don't apply-->

- [ ] The feature or features in this pull request is complete
- [ ] Licensing information is complete
- [ ] Corresponding author information is complete
- [ ] The source code follows the LAMMPS formatting guidelines
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] The added/updated documentation is integrated and tested with the documentation build system
- [ ] The feature has been verified to work with the conventional build system
- [ ] The feature has been verified to work with the CMake based build system
- [ ] Suitable tests have been added to the unittest tree.
- [ ] A package specific README file has been included or updated
- [ ] One or more example input decks are included

**Further Information, Files, and Links**

<!--Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)-->


